### PR TITLE
Dynatrace & JMeter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,19 @@ Installs k3s and keptn quality gates
   * CentOS 8
   * ArchLinux
   * Debian on GCP
+  * Amazon Linux
   
 * Works on a machine with 1 (v)CPU and 4GB of memory
+
+## Parameters
+The script allows a couple of parameters
+| Parameter Name | Value | Comment |
+| ------------- | ------ | --------|
+| --with-prometheus | | Will enable Prometheus Support |
+| --with-dynatrace | | Will enable Dynatrace Support. Requires DT_API_TOKEN and DT_TENANT env variables to be set
+| --with-jmeter | | Will install JMeter Extended Service |
+| --provider | aws,gcp,digitalocean,<empty> | handles IP gathering based on provider |
+| --IP | <YOURIP> | Allows you to pass your own IP of your host |
 
 ## Usage (Autodetect IP, need hostname -I):
 ```
@@ -31,6 +42,11 @@ curl -Lsf https://raw.githubusercontent.com/keptn-sandbox/keptn-on-k3s/master/in
 ## Usage (GCP Instance):
 ```
 curl -Lsf https://raw.githubusercontent.com/keptn-sandbox/keptn-on-k3s/master/install-keptn-on-k3s.sh | bash -s - --provider gcp
+``` 
+
+## Usage (EC2 Instance with Dynatrace & JMeter :
+```
+curl -Lsf https://raw.githubusercontent.com/keptn-sandbox/keptn-on-k3s/master/install-keptn-on-k3s.sh | bash -s - --provider aws --with-dynatrace --with-jmeter
 ``` 
 
 ## Usage (Custom IP):

--- a/install-keptn-on-k3s.sh
+++ b/install-keptn-on-k3s.sh
@@ -236,7 +236,7 @@ function main {
         ;;
     --with-dynatrace)
         DYNA="true"
-        echo "Enabling Dynatrace Support: Requires you to set DT_TENANT, DT_API_TOKEN & DT_PAAS_TOKEN
+        echo "Enabling Dynatrace Support: Requires you to set DT_TENANT, DT_API_TOKEN & DT_PAAS_TOKEN"
         shift
         ;;
     *)


### PR DESCRIPTION
Added installation support for Dynatrace (--with-dynatrace) as well as JMeter (--with-jmeter)
Dynatrace support also validates that the passed api token and tenant are valid and that the api endpoint can be reached